### PR TITLE
add Sync to trait object

### DIFF
--- a/src/v1/aeadcipher.rs
+++ b/src/v1/aeadcipher.rs
@@ -138,7 +138,7 @@ impl_siv_cmac_cipher!(AesSivCmac384, AES_SIV_CMAC_384);
 impl_siv_cmac_cipher!(AesSivCmac512, AES_SIV_CMAC_512);
 
 pub struct AeadCipher {
-    cipher: Box<dyn AeadCipherInner + Send + 'static>,
+    cipher: Box<dyn AeadCipherInner + Send + Sync + 'static>,
     nlen: usize,
     nonce: [u8; Self::N_MAX],
 }
@@ -149,7 +149,7 @@ impl AeadCipher {
     pub fn new(kind: CipherKind, key: &[u8]) -> Self {
         use self::CipherKind::*;
 
-        let cipher: Box<dyn AeadCipherInner + Send + 'static> = match kind {
+        let cipher: Box<dyn AeadCipherInner + Send + Sync + 'static> = match kind {
             AES_128_CCM => Box::new(Aes128Ccm::new(key)),
             AES_256_CCM => Box::new(Aes256Ccm::new(key)),
             AES_128_OCB_TAGLEN128 => Box::new(Aes128OcbTag128::new(key)),

--- a/src/v1/cipher.rs
+++ b/src/v1/cipher.rs
@@ -218,7 +218,7 @@ impl CipherInner for AeadCipher {
 
 /// Unified interface of Ciphers
 pub struct Cipher {
-    cipher: Box<dyn CipherInner + Send + 'static>,
+    cipher: Box<dyn CipherInner + Send + Sync + 'static>,
 }
 
 impl Cipher {

--- a/src/v1/streamcipher/mod.rs
+++ b/src/v1/streamcipher/mod.rs
@@ -96,14 +96,14 @@ impl_cipher!(Rc4, RC4);
 impl_cipher!(Chacha20, CHACHA20);
 
 pub struct StreamCipher {
-    cipher: Box<dyn StreamCipherInner + Send + 'static>,
+    cipher: Box<dyn StreamCipherInner + Send + Sync + 'static>,
 }
 
 impl StreamCipher {
     pub fn new(kind: CipherKind, key: &[u8], iv: &[u8]) -> Self {
         use self::CipherKind::*;
 
-        let cipher: Box<dyn StreamCipherInner + Send + 'static> = match kind {
+        let cipher: Box<dyn StreamCipherInner + Send + Sync + 'static> = match kind {
             SS_TABLE => Box::new(Table::new(key, iv)),
             SS_RC4_MD5 => Box::new(Rc4Md5::new(key, iv)),
             AES_128_CTR => Box::new(Aes128Ctr::new(key, iv)),


### PR DESCRIPTION
Added because all ciphers could be `Sync`.

Because the current [`Cipher`](https://docs.rs/shadowsocks-crypto/0.1.2/shadowsocks_crypto/v1/struct.Cipher.html#impl-Sync) is `!Sync`, I can not use it in my library : )