### PR TITLE
fix: compile error on aarch64-apple-ios

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ aes = { version = "0.7.5", features = ["ctr"], optional = true }
 md-5 = { version = "0.10", features = ["asm"] }
 sha1 = { version = "0.10", features = ["asm"], optional = true }
 
-[target.'cfg(all(unix, target_arch = "aarch64"))'.dependencies]
+[target.'cfg(all(unix, target_arch = "aarch64", not(target_os = "ios")))'.dependencies]
 sha1 = { version = "0.10", features = ["asm"], optional = true }
 
 #[target.'cfg(all(windows, any(target_arch = "x86", target_arch = "x86_64"), target_env = "gnu"))'.dependencies]


### PR DESCRIPTION
It fails to build when targeting to `aarch64-apple-ios`.

```
error[E0433]: failed to resolve: could not find `__detect_target_features` in `$crate`
 --> ~/.cargo/registry/src/github.com-1ecc6299db9ec823/sha1-0.10.1/src/compress/aarch64.rs:8:1
  |
8 | cpufeatures::new!(sha1_hwcap, "sha2");
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ could not find `__detect_target_features` in `$crate`
  |
  = note: this error originates in the macro `cpufeatures::new` (in Nightly builds, run with -Z macro-backtrace for more info)

For more information about this error, try `rustc --explain E0433`.
error: could not compile `sha1` due to previous error
```

Fixed by disabling `asm` feature in `sha1` crate when `target_os="ios"`