### PR TITLE
chore: reduce indirect dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ aes-gcm = { version = "0.10", optional = true }
 aes-gcm-siv = { version = "0.11", optional = true }
 ccm = { version = "0.5", optional = true }
 chacha20poly1305 = { version = "0.10", optional = true }
-ring-compat = { version = "0.8", optional = true }
+ring-compat = { version = "0.8", default-features = false, features = ["aead", "alloc"], optional = true }
 md-5 = { version = "0.10", optional = true }
 hkdf = { version = "0.12", optional = true }
 sha1 = { version = "0.10", optional = true }


### PR DESCRIPTION
We don't use `ring-compat::digest` and `ring-compat::signature`.
Removing unused features avoids compiling unneeded indirect dependencies (`crypto-bigint`, `ecdsa`, `elliptic-curve`, `p256`, `p384`, etc.).
Thus, it will speed up compile time.